### PR TITLE
Add initial unit tests

### DIFF
--- a/backend/src/utils/phoneUtils.test.js
+++ b/backend/src/utils/phoneUtils.test.js
@@ -1,0 +1,34 @@
+import { normalizePhoneNumber, formatPhoneNumber, isValidIranianMobile } from './phoneUtils.js';
+
+describe('phoneUtils', () => {
+  describe('normalizePhoneNumber', () => {
+    test('removes country code and leading zero', () => {
+      expect(normalizePhoneNumber('989121234567')).toBe('9121234567');
+      expect(normalizePhoneNumber('09121234567')).toBe('9121234567');
+    });
+
+    test('returns the phone if invalid', () => {
+      expect(normalizePhoneNumber('abc')).toBe('abc');
+    });
+  });
+
+  describe('formatPhoneNumber', () => {
+    test('formats valid phone number', () => {
+      expect(formatPhoneNumber('09121234567')).toBe('09121 234 567');
+    });
+
+    test('returns original for invalid numbers', () => {
+      expect(formatPhoneNumber('abc')).toBe('abc');
+    });
+  });
+
+  describe('isValidIranianMobile', () => {
+    test('detects valid numbers', () => {
+      expect(isValidIranianMobile('09121234567')).toBe(true);
+    });
+
+    test('detects invalid numbers', () => {
+      expect(isValidIranianMobile('12345')).toBe(false);
+    });
+  });
+});


### PR DESCRIPTION
## Summary
- add Jest unit tests for phone utilities

## Testing
- `npm test` in `backend`
- `npm test -- -w=0` in `frontend` *(no tests found)*

------
https://chatgpt.com/codex/tasks/task_b_6872aa31737c83328a11282f3e3a8f17