### PR TITLE
Fix phone normalization bug

### DIFF
--- a/backend/src/utils/phoneUtils.js
+++ b/backend/src/utils/phoneUtils.js
@@ -14,6 +14,11 @@ export const normalizePhoneNumber = (phone) => {
   // Remove all non-digit characters
   let normalizedPhone = phone.toString().replace(/\D/g, '');
 
+  // Remove international prefix "00" if present
+  if (normalizedPhone.startsWith('00')) {
+    normalizedPhone = normalizedPhone.substring(2);
+  }
+
   // Remove country code (98) if present
   if (normalizedPhone.startsWith('98')) {
     normalizedPhone = normalizedPhone.substring(2);

--- a/backend/src/utils/phoneUtils.test.js
+++ b/backend/src/utils/phoneUtils.test.js
@@ -5,6 +5,8 @@ describe('phoneUtils', () => {
     test('removes country code and leading zero', () => {
       expect(normalizePhoneNumber('989121234567')).toBe('9121234567');
       expect(normalizePhoneNumber('09121234567')).toBe('9121234567');
+      expect(normalizePhoneNumber('+989121234567')).toBe('9121234567');
+      expect(normalizePhoneNumber('00989121234567')).toBe('9121234567');
     });
 
     test('returns the phone if invalid', () => {
@@ -25,6 +27,7 @@ describe('phoneUtils', () => {
   describe('isValidIranianMobile', () => {
     test('detects valid numbers', () => {
       expect(isValidIranianMobile('09121234567')).toBe(true);
+      expect(isValidIranianMobile('00989121234567')).toBe(true);
     });
 
     test('detects invalid numbers', () => {


### PR DESCRIPTION
## Summary
- improve phone normalization by stripping international `00` prefix
- add tests for phone numbers with `+98` and `0098` prefixes

## Testing
- `npm test --silent` *(fails: Cannot find module 'jest')*

------
https://chatgpt.com/codex/tasks/task_b_6873d23bb87883329cf970372c44333e